### PR TITLE
Remove commented line before parsing

### DIFF
--- a/CppFile.js
+++ b/CppFile.js
@@ -1,7 +1,7 @@
 /*
  * CppFile.js - plugin to extract resources from a C++ source code file
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,22 @@ CppFile.trimComment = function(commentString) {
     return trimComment;
 }
 
+/**
+ * Remove single and multi-lines comments except for i18n comment style.
+ *
+ * @private
+ * @param {String} string the string to clean
+ * @returns {String} the cleaned string
+*/
+ CppFile.removeCommentLines = function(data) {
+    if (!data) return;
+    // comment style: // , /* */ single, multi line
+    var trimData = data.replace(/\/\/\s*((?!i18n).)*[$/\n]/g, "").
+                replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "").
+                replace(/\/\*(((?!i18n).)*)\*\//g, "");
+    return trimData;
+ };
+
 var reGetLocString = new RegExp(/\bgetLocString\(\s*"((\\"|[^"])*)"\s*\)/g);
 var reGetLocStringWithKey = new RegExp(/\bgetLocString\(\s*"((\\"|[^"])*)"\s*,\s*"((\\"|[^"])*)"\)/g);
 var reI18nComment = new RegExp(/\/(\*|\/)\s*i18n\s*(.*)($|\*\/)/);
@@ -99,6 +115,8 @@ var reI18nComment = new RegExp(/\/(\*|\/)\s*i18n\s*(.*)($|\*\/)/);
  */
 CppFile.prototype.parse = function(data) {
     logger.debug("Extracting strings from " + this.pathName);
+
+    data = CppFile.removeCommentLines(data);
     this.resourceIndex = 0;
 
     var comment, match, key;

--- a/CppFileType.js
+++ b/CppFileType.js
@@ -1,7 +1,7 @@
 /*
  * CppFileType.js - Represents a collection of C++ files
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ilib-webos-loctool-cpp is a plugin for the loctool allows it to read and localize cpp files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.1.0
+* Removed commented lines before parsing so that strings in the comments will not be extracted.
+
 v1.0.1
 * Updated code to print log with log4js.
 
@@ -10,7 +13,7 @@ v1.0.0
 
 ## License
 
-Copyright © 2020, JEDLSoft
+Copyright © 2020-2021, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-cpp",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "main": "./CppFileType.js",
     "description": "A loctool plugin that knows how to process C++ files",
     "license": "Apache-2.0",

--- a/test/assertExtras.js
+++ b/test/assertExtras.js
@@ -1,7 +1,7 @@
 /*
  * assertExtras.js - extra assertion types to use with nodeunit
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testCppFile.js
+++ b/test/testCppFile.js
@@ -870,5 +870,5 @@ module.exports.cppfile = {
         test.ok(set);
         test.equal(set.size(), 0);
         test.done();
-    },
+    }
 };

--- a/test/testCppFile.js
+++ b/test/testCppFile.js
@@ -1,7 +1,7 @@
 /*
  * testCppFile.js - test the C++ file handler object.
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ module.exports.cppfile = {
 
         var cppf = new CppFile({
             project: p,
-            pathName: "./testfiles/t1.c",
+            pathName: "./testfiles/t1.cpp",
             type: cppft
         });
 
@@ -390,7 +390,7 @@ module.exports.cppfile = {
         });
         test.ok(cppf);
 
-        cppf.parse('i18n_yes    = ResBundleAdaptor::Instance().getLocString("Yes"); // i18n  /** Connect WiSA Dongle **/ ');
+        cppf.parse('i18n_yes    = ResBundleAdaptor::Instance().getLocString("Yes"); // i18n  Connect WiSA Dongle');
 
         var set = cppf.getTranslationSet();
         test.ok(set);
@@ -833,8 +833,42 @@ module.exports.cppfile = {
         cppf.extract();
 
         var set = cppf.getTranslationSet();
-        test.equal(set.size(), 0);
+        test.equal(set.size(), 1);
 
         test.done();
-    }
+    },
+    testCppFileNotParseCommentLine: function(test) {
+        test.expect(3);
+
+        var cppf = new CppFile({
+            project: p,
+            pathName: undefined,
+            type: cppft
+        });
+        test.ok(cppf);
+
+        cppf.parse('// ResBundleAdaptor::Instance().getLocString(" Yes ");\n');
+
+        var set = cppf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+        test.done();
+    },
+    testCppFileNotParseCommentLine2: function(test) {
+        test.expect(3);
+
+        var cppf = new CppFile({
+            project: p,
+            pathName: undefined,
+            type: cppft
+        });
+        test.ok(cppf);
+
+        cppf.parse('/* ResBundleAdaptor::Instance().getLocString("NO"); */\n');
+
+        var set = cppf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 0);
+        test.done();
+    },
 };

--- a/test/testCppFileType.js
+++ b/test/testCppFileType.js
@@ -1,7 +1,7 @@
 /*
  * testCppFileType.js - test the C++ file type handler object.
  *
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuite.js
+++ b/test/testSuite.js
@@ -1,7 +1,7 @@
 /*
  * testSuite.js - test suite for this directory
  * 
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testSuiteFiles.js
+++ b/test/testSuiteFiles.js
@@ -1,7 +1,7 @@
 /*
  * testSuiteFiles.js - list the test files in this directory
  * 
- * Copyright © 2020, JEDLSoft
+ * Copyright © 2020-2021, JEDLSoft
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/testfiles/t3.cpp
+++ b/test/testfiles/t3.cpp
@@ -1,0 +1,7 @@
+// test1 = ResBundleAdaptor::Instance().getLocString("You're\n Welcome.");
+/* test2 = ResBundleAdaptor::Instance().getLocString("No,\n \t Thanks.");*/
+/*
+* test3  = ResBundleAdaptor::Instance().getLocString("Yes \"yes\".");
+*/
+
+/*test4 = ResBundleAdaptor::Instance().getLocString("No"); */test5 = ResBundleAdaptor::Instance().getLocString("Yes \"yes\".");


### PR DESCRIPTION
* Remove commented line before parsing so that strings in the comments will not be extracted.
* When the i18n is founded in comments, it treats `i18n comment style always (it works same as webos-c plugin)
```
// i18n comments
/* i18n  comments */
```
* Add test cases and update copyright year