### PR TITLE
Update dependent module version to have the latest one (loctool:2.13.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ilib-webos-loctool-cpp is a plugin for the loctool allows it to read and localize cpp files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.1.3
+* Updated dependent module version to have the latest one. (loctool: 2.13.0)
+
 v1.1.2
 * Updated dependent module version to have the latest one. (loctool: 2.12.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-cpp",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "main": "./CppFileType.js",
     "description": "A loctool plugin that knows how to process C++ files",
     "license": "Apache-2.0",
@@ -50,11 +50,11 @@
     },
     "dependencies": {
         "ilib": "^14.8.0",
-        "ilib-loctool-webos-json-resource": "1.3.6",
+        "ilib-loctool-webos-json-resource": "1.3.7",
         "log4js": "^5.0.0"
     },
     "devDependencies": {
-        "loctool": "2.12.0",
+        "loctool": "2.13.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
Update dependent module version to have the latest one
```
loctool 2.13.0
ilib-loctool-webos-json-resource: 1.3.7
```