### PR TITLE
Strings are not extracted due to incorrect deletion of commented lines

### DIFF
--- a/CppFile.js
+++ b/CppFile.js
@@ -96,8 +96,8 @@ CppFile.trimComment = function(commentString) {
     if (!data) return;
     // comment style: // , /* */ single, multi line
     var trimData = data.replace(/\/\/\s*((?!i18n).)*[$/\n]/g, "").
-                replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "").
-                replace(/\/\*(((?!i18n).)*)\*\//g, "");
+                replace(/\/\*(((?!i18n).)*)\*\//g, "").
+                replace(/\/\*+((?!i18n)[^*]|\*(?!\/))*\*+\//g, "");
     return trimData;
  };
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 ilib-webos-loctool-cpp is a plugin for the loctool allows it to read and localize cpp files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.1.7
+* Fixed an issue where strings are not extracted due to incorrect deletion of commented lines.
+
 v1.1.6
 * Updated dependencies.(loctool: 2.16.3)
 * Used the logger provided by the loctool instead of using log4js directly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-cpp",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "main": "./CppFileType.js",
     "description": "A loctool plugin that knows how to process C++ files",
     "license": "Apache-2.0",

--- a/test/testCppFile.js
+++ b/test/testCppFile.js
@@ -833,7 +833,7 @@ module.exports.cppfile = {
         cppf.extract();
 
         var set = cppf.getTranslationSet();
-        test.equal(set.size(), 1);
+        test.equal(set.size(), 3);
 
         test.done();
     },

--- a/test/testfiles/t3.cpp
+++ b/test/testfiles/t3.cpp
@@ -5,3 +5,12 @@
 */
 
 /*test4 = ResBundleAdaptor::Instance().getLocString("No"); */test5 = ResBundleAdaptor::Instance().getLocString("Yes \"yes\".");
+
+/**********************/
+/* check type */
+/**********************/
+test6 = resBundle->getLocString("More 1");
+/**********************/
+/* check appid */
+/**********************/
+test7 = resBundle->getLocString("More 2");


### PR DESCRIPTION
* Strings are not extracted due to incorrect deletion of commented lines
  *  Delete a single commented line first and then remove the multi-lines.