### PR TITLE
Add langage default locale translation comparison logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ ilib-webos-loctool-cpp is a plugin for the loctool allows it to read and localiz
 
 ## Release Notes
 v1.1.7
+* Updated dependencies. (loctool: 2.17.0)
 * Fixed an issue where strings are not extracted due to incorrect deletion of commented lines.
+* Updated to check language default locale translation not to generate duplicate resources.
 
 v1.1.6
 * Updated dependencies.(loctool: 2.16.3)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.16.3",
+        "loctool": "2.17.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
* Updated to check language default locale translation not to generate duplicate resources.
* same changes with webos-javascript plugin (https://github.com/iLib-js/ilib-loctool-webos-javascript/pull/33)
* sample app to check: https://github.com/iLib-js/ilib-loctool-samples/pull/23 