### PR TITLE
Add a feature to use common xliff data files for localization

### DIFF
--- a/CppFileType.js
+++ b/CppFileType.js
@@ -20,6 +20,8 @@ var path = require("path");
 var CppFile = require("./CppFile.js");
 var JsonResourceFileType = require("ilib-loctool-webos-json-resource");
 var Utils = require("loctool/lib/utils.js")
+var fs = require("fs");
+var path = require("path");
 
 var CppFileType = function(project) {
     this.type = "cpp";
@@ -28,6 +30,7 @@ var CppFileType = function(project) {
     this.project = project;
     this.API = project.getAPI();
     this.extensions = [ ".cpp"];
+    this.isloadCommonData = false;
     this.logger = this.API.getLogger("loctool.plugin.webOSCppFileType");
     this.extracted = this.API.newTranslationSet(project.getSourceLocale());
     this.newres = this.API.newTranslationSet(project.getSourceLocale());
@@ -35,6 +38,10 @@ var CppFileType = function(project) {
 
     if (Object.keys(project.localeMap).length > 0) {
         Utils.setBaseLocale(project.localeMap);
+    }
+
+    if (project.settings.webos && project.settings.webos["commonXliff"]){
+        this.commonPath = project.settings.webos["commonXliff"];
     }
 };
 
@@ -87,6 +94,11 @@ CppFileType.prototype.write = function(translations, locales) {
             return locale !== this.project.sourceLocale && locale !== this.project.pseudoLocale;
         }.bind(this));
 
+    if (this.commonPath && !this.isloadCommonData) {
+        this._loadCommonXliff(translationLocales);
+        this.isloadCommonData = true;
+    }
+
     if (mode === "localize") {
         for (var i = 0; i < resources.length; i++) {
             res = resources[i];
@@ -119,7 +131,43 @@ CppFileType.prototype.write = function(translations, locales) {
     
                 db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(locale), function(err, translated) {
                     var r = translated;
-                    if (!translated && customInheritLocale){
+                    if (!translated && this.isloadCommonData) {
+                        var manipulateKey = res.cleanHashKeyForTranslation(locale).
+                                            replace(res.getProject(), this.commonPrjName).
+                                            replace("_" + res.getDataType() + "_", "_" + this.commonPrjType + "_");
+                        db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
+                            if (translated) {
+                                translated.project = res.getProject();
+                                translated.datatype=res.getDataType();
+                                file = resFileType.getResourceFile(locale);
+                                file.addResource(translated);
+                            } else if(!translated && customInheritLocale){
+                                db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(customInheritLocale), function(err, translated) {
+                                    if (translated){
+                                        translated.setTargetLocale(locale);
+                                        file = resFileType.getResourceFile(locale);
+                                        file.addResource(translated);
+                                    } else {
+                                        var newres = res.clone();
+                                        newres.setTargetLocale(locale);
+                                        newres.setTarget((r && r.getTarget()) || res.getSource());
+                                        newres.setState("new");
+                                        newres.setComment(note);
+                                        this.newres.add(newres);
+                                        this.logger.trace("No translation for " + res.reskey + " to " + locale);
+                                    }
+                                }.bind(this));
+                            } else {
+                                var newres = res.clone();
+                                newres.setTargetLocale(locale);
+                                newres.setTarget((r && r.getTarget()) || res.getSource());
+                                newres.setState("new");
+                                newres.setComment(note);
+                                this.newres.add(newres);
+                                this.logger.trace("No translation for " + res.reskey + " to " + locale);
+                            }
+                        }.bind(this));
+                    } else if (!translated && customInheritLocale){
                         db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(customInheritLocale), function(err, translated) {
                             if (translated) {
                                 translated.setTargetLocale(locale);
@@ -187,6 +235,31 @@ CppFileType.prototype.write = function(translations, locales) {
             this.logger.trace("Added " + res.reskey + " to " + file.pathName);
         }
     }
+};
+
+CppFileType.prototype._loadCommonXliff = function() {
+    if (fs.existsSync(this.commonPath)){
+        var list = fs.readdirSync(this.commonPath);
+    }
+    list.forEach(function(file){
+        var commonXliff = this.API.newXliff({
+            sourceLocale: this.project.getSourceLocale(),
+            project: this.project.getProjectId(),
+            path: this.commonPath,
+        });
+        var pathName = path.join(this.commonPath, file);
+        var data = fs.readFileSync(pathName, "utf-8");
+        commonXliff.deserialize(data);
+        var resources = commonXliff.getResources();
+        var localts = this.project.getRepository().getTranslationSet();
+        if (resources.length > 0){
+            this.commonPrjName = resources[0].getProject();
+            this.commonPrjType = resources[0].getDataType();
+            resources.forEach(function(res){
+                localts.add(res);
+            }.bind(this));
+        }
+    }.bind(this));
 };
 
 CppFileType.prototype.newFile = function(path) {

--- a/CppFileType.js
+++ b/CppFileType.js
@@ -16,12 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+var fs = require("fs");
 var path = require("path");
 var CppFile = require("./CppFile.js");
 var JsonResourceFileType = require("ilib-loctool-webos-json-resource");
 var Utils = require("loctool/lib/utils.js")
-var fs = require("fs");
-var path = require("path");
+var ResourceString = require("loctool/lib/ResourceString.js");
 
 var CppFileType = function(project) {
     this.type = "cpp";
@@ -132,9 +133,7 @@ CppFileType.prototype.write = function(translations, locales) {
                 db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(locale), function(err, translated) {
                     var r = translated;
                     if (!translated && this.isloadCommonData) {
-                        var manipulateKey = res.cleanHashKeyForTranslation(locale).
-                                            replace(res.getProject(), this.commonPrjName).
-                                            replace("_" + res.getDataType() + "_", "_" + this.commonPrjType + "_");
+                        var manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey(), this.commonPrjType, res.getFlavor());
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
                             if (translated) {
                                 translated.project = res.getProject();

--- a/README.md
+++ b/README.md
@@ -3,13 +3,37 @@ ilib-webos-loctool-cpp is a plugin for the loctool allows it to read and localiz
 
 ## Release Notes
 v1.3.0
-* Updated dependencies. (loctool: 2.19.0)
+* Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.
+  * i.e) en-AU inherits translations from en-GB
+    ~~~~
+       "settings": {
+            "localeInherit": {
+                "en-AU": "en-GB"
+            }
+        }
+    ~~~~
+* Added ability to use common locale data.
+  * App's xliff data has a higher priority, if there's no matched string there, then loctool checks data in the commonXliff directory.
+    ~~~~
+       "settings": {
+            "webos": {
+                "commonXliff": "./common"
+            }
+        }
+    ~~~~
 
 v1.2.0
 * Updated dependencies. (loctool: 2.18.0)
 * Updated to support loctool's generate mode.
 * Added ability to override language default locale.
+    ~~~~
+       "settings": {
+            "localeMap": {
+                "es-CO": "es"
+            }
+        }
+    ~~~~
 
 v1.1.7
 * Updated dependencies. (loctool: 2.17.0)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "2.19.0",
+        "loctool": "2.20.0",
         "nodeunit": "^0.11.3"
     }
 }


### PR DESCRIPTION
Added ability to use common locale data.
App's xliff data has a higher priority, if there's no matched string there, then loctool checks data in the common directory
depent loctool package version should be `2.20.0` as minumum
  * related PR: https://github.com/iLib-js/loctool/pull/212
  * sample: https://github.com/iLib-js/ilib-loctool-samples/pull/33