### PR TITLE
Fixed some issue cases

### DIFF
--- a/CppFileType.js
+++ b/CppFileType.js
@@ -96,7 +96,7 @@ CppFileType.prototype.write = function(translations, locales) {
         }.bind(this));
 
     if (this.commonPath && !this.isloadCommonData) {
-        this._loadCommonXliff(translationLocales);
+        this._loadCommonXliff();
         this.isloadCommonData = true;
     }
 
@@ -112,9 +112,6 @@ CppFileType.prototype.write = function(translations, locales) {
                 langDefaultLocale = Utils.getBaseLocale(locale);
 
                 customInheritLocale = this.project.getLocaleInherit(locale);
-                if (customInheritLocale) {
-                    langDefaultLocale = customInheritLocale;
-                }
 
                 baseTranslation = res.getSource();
     
@@ -135,17 +132,19 @@ CppFileType.prototype.write = function(translations, locales) {
                     if (!translated && this.isloadCommonData) {
                         var manipulateKey = ResourceString.hashKey(this.commonPrjName, locale, res.getKey(), this.commonPrjType, res.getFlavor());
                         db.getResourceByCleanHashKey(manipulateKey, function(err, translated) {
-                            if (translated) {
-                                translated.project = res.getProject();
-                                translated.datatype=res.getDataType();
+                            if (translated && (baseTranslation !== translated.getTarget())){
+                                var newres = translated.clone();
+                                newres.project = res.getProject();
+                                newres.datatype = res.getDataType();
                                 file = resFileType.getResourceFile(locale);
-                                file.addResource(translated);
+                                file.addResource(newres);
                             } else if(!translated && customInheritLocale){
                                 db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(customInheritLocale), function(err, translated) {
-                                    if (translated){
-                                        translated.setTargetLocale(locale);
+                                    if (translated && (baseTranslation !== translated.getTarget())){
+                                        var newres = translated.clone();
+                                        newres.setTargetLocale(locale);
                                         file = resFileType.getResourceFile(locale);
-                                        file.addResource(translated);
+                                        file.addResource(newres);
                                     } else {
                                         var newres = res.clone();
                                         newres.setTargetLocale(locale);
@@ -168,10 +167,11 @@ CppFileType.prototype.write = function(translations, locales) {
                         }.bind(this));
                     } else if (!translated && customInheritLocale){
                         db.getResourceByCleanHashKey(res.cleanHashKeyForTranslation(customInheritLocale), function(err, translated) {
-                            if (translated) {
-                                translated.setTargetLocale(locale);
+                            if (translated && (baseTranslation !== translated.getTarget())){
+                                var newres = translated.clone();
+                                newres.setTargetLocale(locale);
                                 file = resFileType.getResourceFile(locale);
-                                file.addResource(translated);
+                                file.addResource(newres);
                             } else {
                                 var newres = res.clone();
                                 newres.setTargetLocale(locale);
@@ -223,15 +223,68 @@ CppFileType.prototype.write = function(translations, locales) {
         }.bind(this));
     } else {
         // generate mode
-        resources = this.project.getTranslations(translationLocales);
-    }
+        this.genresources = this.project.getTranslations(translationLocales);
+        this.customInherit = translationLocales.filter(function(locale){
+            return this.project.getLocaleInherit(locale) !== undefined;
+        }.bind(this));
 
-    for (var i = 0; i < resources.length; i++) {
-        res = resources[i];
-        if (res.getTargetLocale() !== this.project.sourceLocale && res.getSource() !== res.getTarget()) {
-            file = resFileType.getResourceFile(res.getTargetLocale());
-            file.addResource(res);
-            this.logger.trace("Added " + res.reskey + " to " + file.pathName);
+        if (this.customInherit.length > 0) {
+            this.customInherit.forEach(function(lo){
+                var res = this.project.getTranslations([lo]);
+                if (res.length == 0) {
+                    var inheritlocale = this.project.getLocaleInherit(lo);
+                    var inheritlocaleRes = this.project.getTranslations([inheritlocale]);
+                    inheritlocaleRes.forEach(function(r){
+                        var newres = r.clone();
+                        newres.setTargetLocale(lo);
+                        this.genresources.push(newres);
+                    }.bind(this))
+                }
+            }.bind(this));
+        }
+    }
+    if (mode === "localize") {
+        for (var i = 0; i < resources.length; i++) {
+            res = resources[i];
+            if (res.getTargetLocale() !== this.project.sourceLocale && res.getSource() !== res.getTarget()) {
+                file = resFileType.getResourceFile(res.getTargetLocale());
+                file.addResource(res);
+                this.logger.trace("Added " + res.reskey + " to " + file.pathName);
+            }
+        }
+    } else {
+        // generate mode:  compare baseTranslation data
+        var locale;
+        for (var i = 0; i< this.genresources.length;i++) {
+            res = this.genresources[i];
+            locale = res.getTargetLocale();
+            baseLocale = Utils.isBaseLocale(locale);
+            langDefaultLocale = Utils.getBaseLocale(locale);
+            baseTranslation = res.getSource();
+
+            if (baseLocale){
+                langDefaultLocale = "en-US";
+            }
+            var langkey = res.cleanHashKeyForTranslation(langDefaultLocale);
+            var enUSKey = res.cleanHashKeyForTranslation("en-US");
+
+            db.getResourceByCleanHashKey(langkey, function(err, translated) {
+                if (translated){
+                    baseTranslation = translated.getTarget();
+                } else {
+                    db.getResourceByCleanHashKey(enUSKey, function(err, translated) {
+                        if (translated){
+                            baseTranslation = translated.getTarget();
+                        }
+                    }.bind(this));
+                }
+            }.bind(this));
+
+            if ((locale == "en-US" && res.getSource() !== res.getTarget()) ||
+                (baseTranslation !== res.getTarget())) {
+                file = resFileType.getResourceFile(res.getTargetLocale());
+                file.addResource(res);
+            }
         }
     }
 };
@@ -240,25 +293,27 @@ CppFileType.prototype._loadCommonXliff = function() {
     if (fs.existsSync(this.commonPath)){
         var list = fs.readdirSync(this.commonPath);
     }
-    list.forEach(function(file){
-        var commonXliff = this.API.newXliff({
-            sourceLocale: this.project.getSourceLocale(),
-            project: this.project.getProjectId(),
-            path: this.commonPath,
-        });
-        var pathName = path.join(this.commonPath, file);
-        var data = fs.readFileSync(pathName, "utf-8");
-        commonXliff.deserialize(data);
-        var resources = commonXliff.getResources();
-        var localts = this.project.getRepository().getTranslationSet();
-        if (resources.length > 0){
-            this.commonPrjName = resources[0].getProject();
-            this.commonPrjType = resources[0].getDataType();
-            resources.forEach(function(res){
-                localts.add(res);
-            }.bind(this));
-        }
-    }.bind(this));
+    if (list && list.length !== 0) {
+        list.forEach(function(file){
+            var commonXliff = this.API.newXliff({
+                sourceLocale: this.project.getSourceLocale(),
+                project: this.project.getProjectId(),
+                path: this.commonPath,
+            });
+            var pathName = path.join(this.commonPath, file);
+            var data = fs.readFileSync(pathName, "utf-8");
+            commonXliff.deserialize(data);
+            var resources = commonXliff.getResources();
+            var localts = this.project.getRepository().getTranslationSet();
+            if (resources.length > 0){
+                this.commonPrjName = resources[0].getProject();
+                this.commonPrjType = resources[0].getDataType();
+                resources.forEach(function(res){
+                    localts.add(res);
+                }.bind(this));
+            }
+        }.bind(this));
+    }
 };
 
 CppFileType.prototype.newFile = function(path) {

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 ilib-webos-loctool-cpp is a plugin for the loctool allows it to read and localize cpp files. This plugins is optimized for webOS platform.
 
 ## Release Notes
+v1.4.0
+* Updated to custom locale inheritance feature work properly in generate mode.
+* Added guard code to prevent errors when the common data path is incorrect.
+* Updated to generate resources by comparing base translation data even in generate mode.
+* Fixed an issue where localeinherit related data was not created properly according to the order of locales.
+* Fixed an issue where data is duplicated when it is the same as base translation in generate mode.
+
 v1.3.0
 * Updated dependencies. (loctool: 2.20.0)
 * Added ability to define custom locale inheritance.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-cpp",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "./CppFileType.js",
     "description": "A loctool plugin that knows how to process C++ files",
     "license": "Apache-2.0",


### PR DESCRIPTION
The same changes have already been reviewed and applied to webos-javascript plugin.
(PR number: 43, 44, 45, 46, 47)

* Updated to custom locale inheritance feature work properly in generate mode.
* Added guard code to prevent errors when the common data path is incorrect.
* Updated to generate resources by comparing base translation data even in generate mode.
* Fixed an issue where localeinherit related data was not created properly according to the order of locales.
* Fixed an issue where data is duplicated when it is the same as base translation in generate mode.
* Updated sample app: https://github.com/iLib-js/ilib-loctool-samples/pull/41